### PR TITLE
Remove a redundant "and" from mkcmake.1.

### DIFF
--- a/mkcmake.1
+++ b/mkcmake.1
@@ -14,7 +14,7 @@
 .fi
 ..
 .\" ------------------------------------------------------------------
-.TH MKCMAKE 1 "May 25, 2010" "" ""
+.TH MKCMAKE 1 "August 10, 2012" "" ""
 .SH NAME
 mkcmake \- wrapper for bmake using mk-configure's Mk files and sys.mk
 .SH SYNOPSIS
@@ -24,7 +24,7 @@ mkcmake \- wrapper for bmake using mk-configure's Mk files and sys.mk
 is a trivial wrapper for NetBSD make
 .RB ( bmake )
 that uses
-and mk-configure's Mk files and sys.mk.
+mk-configure's Mk files and sys.mk.
 In all other aspects it is full equivalent of
 .BR bmake .
 .SH OPTIONS


### PR DESCRIPTION
This is a fix for a typo in a man page.
