### PR TITLE
Backwards-compatibly change ‘endianess’ to ‘endianness’.

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,7 @@ mk-configure features:
    libraries and function implementation, function definitions,
    defines, types, struct members etc.
 
- - A number of built-in checks for, e.g., system endianess, GNU bison
+ - A number of built-in checks for, e.g., system endianness, GNU bison
    or GNU flex programs and many others.
 
  - Automatic dependency analysis built-in for C, C++ and Fortran (not

--- a/custom/Makefile
+++ b/custom/Makefile
@@ -1,4 +1,4 @@
-SCRIPTS    =	endianess prog_bison prog_flex prog_gawk prog_gm4
+SCRIPTS    =	endianness prog_bison prog_flex prog_gawk prog_gm4
 
 SCRIPTSDIR =	${BUILTINSDIR}
 

--- a/custom/endianness
+++ b/custom/endianness
@@ -13,7 +13,7 @@ export LC_ALL
 
 ##################################################
 
-pathpart=endianess
+pathpart=endianness
 . mkc_check_common.sh
 
 trap "rm -f $tmpc $tmpo" 0

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -4,7 +4,7 @@ See individual files for details.
 
 ######################################################################
 
-Copyright (c) 2009-2013 by Aleksey Cheusov
+Copyright (c) 2009-2014 by Aleksey Cheusov
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -616,7 +616,7 @@ Version 0.13.0, by Aleksey Cheusov, Sun, 27 Dec 2009 17:06:06 +0200
 
   So called built-in checks are implemented. See MKC_CHECK_BUILTINS
   variable. Built-in checks are checks provided by mk-configure. At
-  the moment the following checks are implemented: endianess,
+  the moment the following checks are implemented: endianness,
   prog_flex, prog_bison, prog_gawk, prog_gm4. See mk-configure.7 for
   the documentation.
 

--- a/doc/TODO
+++ b/doc/TODO
@@ -140,7 +140,7 @@ Plan 2)
   - mkc_imp.filelist.mk
     - FL_NOPREFIX
     - FL_PERSUBPRJ
-  - IRIX: "endianess" and EXPORT_SYMBOLS
+  - IRIX: "endianness" and EXPORT_SYMBOLS
 
 ============================================================
 Plan 3)

--- a/examples/hello_customtests/Makefile
+++ b/examples/hello_customtests/Makefile
@@ -14,13 +14,13 @@ MKC_CUSTOM_FN.cxx_with_templates = custom_tests/cxx_with_templates.cc
 MKC_CUSTOM_FN.true_is_available  = custom_tests/true_is_available
 MKC_CUSTOM_FN.shtest             = custom_tests/shtest
 
-MKC_CHECK_BUILTINS +=		endianess
+MKC_CHECK_BUILTINS +=		endianness
 
 MKC_REQD =		0.12.0
 
 .include <mkc.configure.mk>
 
-BUILTIN.endianess ?=
+BUILTIN.endianness ?=
 .if ${BUILTIN.endianess} != little && ${BUILTIN.endianess} != big
 MKC_ERR_MSG =	"Do you run PDP-11?"
 .endif

--- a/examples/hello_customtests/expect.out
+++ b/examples/hello_customtests/expect.out
@@ -8,8 +8,8 @@
 /objdir/_mkc_custom_alloca_in_stdlib_h.res
 /objdir/_mkc_custom_cxx_with_templates.err
 /objdir/_mkc_custom_cxx_with_templates.res
-/objdir/_mkc_custom_endianess.err
-/objdir/_mkc_custom_endianess.res
+/objdir/_mkc_custom_endianness.err
+/objdir/_mkc_custom_endianness.res
 /objdir/_mkc_custom_shtest.err
 /objdir/_mkc_custom_shtest.res
 /objdir/_mkc_custom_true_is_available.err
@@ -47,8 +47,8 @@ shtest is good: NO
 /objdir/_mkc_custom_alloca_in_stdlib_h.res
 /objdir/_mkc_custom_cxx_with_templates.err
 /objdir/_mkc_custom_cxx_with_templates.res
-/objdir/_mkc_custom_endianess.err
-/objdir/_mkc_custom_endianess.res
+/objdir/_mkc_custom_endianness.err
+/objdir/_mkc_custom_endianness.res
 /objdir/_mkc_custom_shtest.err
 /objdir/_mkc_custom_shtest.res
 /objdir/_mkc_custom_true_is_available.err

--- a/mk/configure.mk
+++ b/mk/configure.mk
@@ -68,9 +68,11 @@ mkc.environ=CC='${CC}' CXX='${CXX}' FC='${FC}' CPPFLAGS='${_MKC_CPPFLAGS}' CFLAG
 ######################################################
 # checking for builtin checks
 .for i in ${MKC_CHECK_BUILTINS} ${MKC_REQUIRE_BUILTINS}
-MKC_CUSTOM_FN.${i} ?=	${BUILTINSDIR}/${i}
+.for j in ${i:endianess=endianness}
+MKC_CUSTOM_FN.${i} ?=	${BUILTINSDIR}/${j}
 MKC_CHECK_CUSTOM   +=	${i}
 MKC_REQUIRE_CUSTOM +=	${MKC_REQUIRE_BUILTINS:M${i}}
+.endfor
 .endfor
 
 ######################################################
@@ -263,6 +265,9 @@ MKC_CUSTOM_FN.${c} =	${c}.c
 .endif
 .if empty(MKC_CUSTOM_FN.${c}:M/*)
 MKC_CUSTOM_FN.${c} :=	${MKC_CUSTOM_DIR}/${MKC_CUSTOM_FN.${c}}
+.endif
+.if ${c} == "endianess"
+.warning "endianess test deprecated; use endianness instead"
 .endif
 CUSTOM.${c} !=		env ${mkc.environ} mkc_check_custom ${MKC_CUSTOM_FN.${c}}
 .endif

--- a/presentation/presentation.tex
+++ b/presentation/presentation.tex
@@ -1099,7 +1099,7 @@ hello: ELF 64-bit MSB executable, SPARC V9, relaxed
       (MKC\_\{CHECK,REQUIRE\}\_FUNCLIBS and MKC\_SOURCE\_FUNCLIBS)
     \item \h{checks for programs} (MKC\_\{CHECK,REQUIRE\}\_PROGS)
     \item \h{user's custom checks} (MKC\_\{CHECK,REQUIRE\}\_CUSTOM)
-    \item \h{built-in checks} (MKC\_CHECK\_BUILTINS), e.g. endianess,
+    \item \h{built-in checks} (MKC\_CHECK\_BUILTINS), e.g. endianness,
       prog\_flex, prog\_bison, prog\_gawk or prog\_gm4)
     \end{itemize}
   \end{enumerate}

--- a/scripts/mk-configure.7.in
+++ b/scripts/mk-configure.7.in
@@ -1306,8 +1306,8 @@ as
 .BR prog_mkdep ", " prog_nbmkdep
 Find traditional BSD mkdep(1) or recent NetBSD version of it respectively.
 .TP
-.B endianess
-BUILTIN.endianess variable is set to either
+.B endianness
+BUILTIN.endianness variable is set to either
 .IR little ", " big " or " unknown
 depending on a hardware.
 .RE


### PR DESCRIPTION
The correct spelling is ‘endianness’, with double ‘n’.

This change corrects this, still allowing to use the old name; warning is printed when ‘endianess’ is used.
