### PR TITLE
Fix pkg-config support (closes issue #8).

### DIFF
--- a/mk/mkc_imp.pkg-config.mk
+++ b/mk/mkc_imp.pkg-config.mk
@@ -42,8 +42,8 @@ LDADD.pkg-config.${_ln} != env ${mkc.environ} mkc_check_custom \
     ${PROG.pkg-config} --libs "${_lp}"
 .endif # LDADD.pkg-config.${l}
 
-MKC_CPPFLAGS +=	${CPPFLAGS.pkg-config.${_ln}}
-MKC_LDADD    +=	${LDADD.pkg-config.${_ln}}
+MKC_CPPFLAGS :=	${MKC_CPPFLAGS} ${CPPFLAGS.pkg-config.${_ln}}
+MKC_LDADD    :=	${MKC_LDADD} ${LDADD.pkg-config.${_ln}}
 .endif # PROGS || LIB
 
 .for i in ${PKG_CONFIG_VARS.${_ln}}
@@ -54,7 +54,7 @@ PKG_CONFIG.var.${_ln}.${i} != env ${mkc.environ} mkc_check_custom \
 .endif # PKG_CONFIG.var.${_ln}.${i}
 .endfor # i
 
-MKC_CFLAGS +=	-DHAVE_PKCONFIG_${_id:S/-/_/g:S/+/P/g:S/./_/g}=1
+MKC_CFLAGS :=	${MKC_CFLAGS} -DHAVE_PKGCONFIG_${_id:S/-/_/g:S/+/P/g:S/./_/g}=1
 
 .elif !empty(MKC_REQUIRE_PKGCONFIG:M${l})
 MKC_ERR_MSG := ${MKC_ERR_MSG} "%%%: ${MKC_CACHEDIR}/_mkc_pkgconfig_${_ln}.err"


### PR DESCRIPTION
Append CPPFLAGS/CFLAGS/LDADD using :=, so that _ln and _id variables
are expanded inside the .for/.endfor loop, not later on in
mkc_imp.conf-final.mk. Otherwise, only the last set of flags is added,
but multiple times (see Debian bug #741837).

Also, add -DHAVE_\* flags according to the manual.
