### PR TITLE
Add support for .cxx files as sources for .op and .os targets

### DIFF
--- a/mk/mkc_imp.rules.mk
+++ b/mk/mkc_imp.rules.mk
@@ -26,11 +26,11 @@
 	${MESSAGE.cc}
 	${COMPILE.cc} ${CPPFLAGS_${_PN}} ${CXXFLAGS_${_PN}} \
 		${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}
-.cc.op .C.op .cpp.op:
+.cc.op .C.op .cpp.op .cxx.op:
 	${MESSAGE.cc}
 	${COMPILE.cc} -pg ${CPPFLAGS_${_PN}} ${CXXFLAGS_${_PN}} \
 		${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}
-.cc.os .C.os .cpp.os:
+.cc.os .C.os .cpp.os .cxx.os:
 	${MESSAGE.cc}
 	${COMPILE.cc} ${CXXFLAGS.pic} ${CPPFLAGS_${_PN}} \
 		${CXXFLAGS_${_PN}} ${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}

--- a/mk/mkc_imp.rules.mk
+++ b/mk/mkc_imp.rules.mk
@@ -26,11 +26,11 @@
 	${MESSAGE.cc}
 	${COMPILE.cc} ${CPPFLAGS_${_PN}} ${CXXFLAGS_${_PN}} \
 		${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}
-.cc.op .C.op .cpp.op .cxx.op:
+.cc.op .cpp.op .cxx.op .C.op:
 	${MESSAGE.cc}
 	${COMPILE.cc} -pg ${CPPFLAGS_${_PN}} ${CXXFLAGS_${_PN}} \
 		${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}
-.cc.os .C.os .cpp.os .cxx.os:
+.cc.os .cpp.os .cxx.os .C.os:
 	${MESSAGE.cc}
 	${COMPILE.cc} ${CXXFLAGS.pic} ${CPPFLAGS_${_PN}} \
 		${CXXFLAGS_${_PN}} ${COPTS_${_PN}} -o ${.TARGET} ${.IMPSRC}


### PR DESCRIPTION
A possible fix for #19 .