### PR TITLE
examples/hello_calc2: fix against gcc-10 (multiple definition of `calc_lval')

### DIFF
--- a/examples/hello_calc2/lex.l
+++ b/examples/hello_calc2/lex.l
@@ -20,5 +20,3 @@ id			[a-zA-Z]+
 \n|[-+\/*^()]	{ return yytext[0]; }
 
 %%
-
-YYSTYPE calc_lval;


### PR DESCRIPTION
On gcc-10 'bmake test' fails as:

```
$ PREFIX=/usr SYSCONFDIR=/etc bmake test
...
cc -o calc lex.o parser.o        -lm
ld: parser.o:(.bss+0x8):
  multiple definition of `calc_lval'; lex.o:(.bss+0x28): first defined here
collect2: error: ld returned 1 exit status
*** Error code 1
```

It happens because `calc_lval` is defined in multiple places:
directly via `calc_lval` and via `yylval`.

```
$ egrep -R 'calc_lval|yylval' examples/
examples/hello_calc2/lex.c:#define yylval calc_lval
examples/hello_calc2/lex.c:YYSTYPE calc_lval;
examples/hello_calc2/parser.c:#define yylval          calc_lval
examples/hello_calc2/parser.c:YYSTYPE yylval;
```

gcc-10 will change the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678.

The error also should also happen on CFLAGS=-fno-common passed explicitly.