### PR TITLE
Add support for using .c++ as extension for c++ files

### DIFF
--- a/mk/mkc_imp.checkprogs.mk
+++ b/mk/mkc_imp.checkprogs.mk
@@ -13,7 +13,7 @@ MKC_REQUIRE_PROGS  +=			${CC:[1]}
 MKC_PROG.id.${CC:[1]:S|+|x|g}    =	cc
 .endif
 
-.if !empty(_srcsall:U:M*.cc) || !empty(_srcsall:U:M*.C) || !empty(_srcsall:U:M*.cxx) || !empty(_srcsall:U:M*.cpp) && !empty(CXX)
+.if !empty(_srcsall:U:M*.cc) || !empty(_srcsall:U:M*.C) || !empty(_srcsall:U:M*.cxx) || !empty(_srcsall:U:M*.cpp) || !empty(_srcsall:U:M*.c\+\+) && !empty(CXX)
 MKC_REQUIRE_PROGS  +=			${CXX:[1]}
 MKC_PROG.id.${CXX:[1]:S/+/x/g}   =	cxx
 .endif

--- a/mk/mkc_imp.compiler_type.mk
+++ b/mk/mkc_imp.compiler_type.mk
@@ -3,6 +3,7 @@
 .if empty(src_type:Mcxx)
 .if !empty(_srcsall:U:M*.cxx) || !empty(_srcsall:U:M*.cpp) || \
     !empty(_srcsall:U:M*.C) || !empty(_srcsall:U:M*.cc) || \
+    !empty(_srcsall:U:M*.c\+\+) || \
     !empty(MKC_CHECK_CXX_OPTS:U) || !empty(MKC_CHECK_CXXLD_OPTS:U)
 src_type   +=	cxx
 LDREAL     ?=	${CXX}
@@ -44,7 +45,8 @@ src_type  +=	cc
 .if empty(src_type:Mcxx)
 .  for c in ${MKC_CHECK_CUSTOM:U} ${MKC_REQUIRE_CUSTOM:U}
 .    if !empty(MKC_CUSTOM_FN.${c}:U:M*.cxx) || !empty(MKC_CUSTOM_FN.${c}:U:M*.cpp) || \
-    !empty(MKC_CUSTOM_FN.${c}:U:M*.C) || !empty(MKC_CUSTOM_FN.${c}:U:M*.cc)
+    !empty(MKC_CUSTOM_FN.${c}:U:M*.C) || !empty(MKC_CUSTOM_FN.${c}:U:M*.cc) || \
+    !empty(MKC_CUSTOM_FN.${c}:U:M*.c\+\+)
 src_type  +=	cxx
 .    endif
 .  endfor

--- a/mk/mkc_imp.dep.mk
+++ b/mk/mkc_imp.dep.mk
@@ -21,8 +21,8 @@ MKDEP_CC       ?=	${CC}
 # some of the rules involve .h sources, so remove them from mkdep line
 
 .if defined(_SRCS_ALL)
-__DPSRCS.all  =	${_SRCS_ALL:T:C/\.(c|m|s|S|C|cc|cpp|cxx)$/.d/} \
-		${DPSRCS:T:C/\.(c|m|s|S|C|cc|cpp|cxx)$/.d/}
+__DPSRCS.all  =	${_SRCS_ALL:T:C/\.(c|m|s|S|C|cc|cpp|cxx|c\+\+)$/.d/} \
+		${DPSRCS:T:C/\.(c|m|s|S|C|cc|cpp|cxx|c\+\+)$/.d/}
 __DPSRCS.d    =	${__DPSRCS.all:O:u:M*.d}
 __DPSRCS.notd =	${__DPSRCS.all:O:u:N*.d}
 
@@ -68,7 +68,7 @@ ${.MAKE.DEPENDFILE}: ${__DPSRCS.d}
 	@sed 's/^\([^ ]*\)[.]o\(.*\)$$/${MKDEP_SUFFIXES:C,^,\\\\1,}\2/' ${__DPSRCS.d} > ${.TARGET}
 .endif
 
-.SUFFIXES: .d .s .S .c .C .cc .cpp .cxx
+.SUFFIXES: .d .s .S .c .C .c++ .cc .cpp .cxx
 
 .c.d:
 	${MESSAGE.dep}
@@ -78,7 +78,7 @@ ${.MAKE.DEPENDFILE}: ${__DPSRCS.d}
 	${MESSAGE.dep}
 	@env CC=${MKDEP_CC:Q} ${MKDEP.s} ${.IMPSRC}
 
-.C.d .cc.d .cpp.d .cxx.d:
+.C.d .c++.d .cc.d .cpp.d .cxx.d:
 	${MESSAGE.dep}
 	@env CC=${MKDEP_CC:Q} ${MKDEP.cc} ${.IMPSRC}
 

--- a/mk/mkc_imp.rules.mk
+++ b/mk/mkc_imp.rules.mk
@@ -2,7 +2,7 @@
 #
 # See LICENSE file in the distribution.
 ############################################################
-.SUFFIXES: .a .o .op .os .s .S .c .cc .cpp .cxx .C .y .l .cl .p .h
+.SUFFIXES: .a .o .op .os .s .S .c .c++ .cc .cpp .cxx .C .y .l .cl .p .h
 
 .LIBS:		.a
 
@@ -19,13 +19,13 @@
 	${COMPILE.c} ${CFLAGS.pic} -o ${.TARGET} ${COPTS} ${COPTS_${_PN}} ${.IMPSRC}
 
 # C++
-.cc.o .cpp.o .cxx.o .C.o:
+.c++.o .cc.o .cpp.o .cxx.o .C.o:
 	${MESSAGE.cc}
 	${COMPILE.cc} -o ${.TARGET} ${CXXOPTS} ${CXXOPTS_${_PN}} ${.IMPSRC}
-.cc.op .cpp.op .cxx.op .C.op:
+.c++.op .cc.op .cpp.op .cxx.op .C.op:
 	${MESSAGE.cc}
 	${COMPILE.cc} -o ${.TARGET} ${CXXOPTS} ${CXXOPTS_${_PN}} -pg ${.IMPSRC}
-.cc.os .cpp.os .cxx.os .C.os:
+.c++.os .cc.os .cpp.os .cxx.os .C.os:
 	${MESSAGE.cc}
 	${COMPILE.cc} ${CXXFLAGS.pic} -o ${.TARGET} ${CXXOPTS} ${CXXOPTS_${_PN}} ${.IMPSRC}
 

--- a/scripts/mk-configure.7.in
+++ b/scripts/mk-configure.7.in
@@ -1276,7 +1276,7 @@ MKC_CUSTOM_FN.<custom_check_name> is a
 "C" or "C++" source filename or an executable program
 for your custom check,
 e.g., filename.c, filename.cc, subdir/filename.cxx, filename.C,
-filename.cpp or subdir/executable_script.
+filename.cpp, filename.c++ or subdir/executable_script.
 .B mk-configure
 tries to compile or run the specified file and sets
 CUSTOM.<custom_check_name> variable to 1, 0 or other value.

--- a/scripts/mkc_check_custom.in
+++ b/scripts/mkc_check_custom.in
@@ -122,7 +122,7 @@ check_itself (){
 	    *.c)
 		compiler="$CC"
 		flags="-o $tmpo $CFLAGS $CPPFLAGS $src_or_exe";;
-	    *.cc|*.C|*.cxx|*.cpp)
+	    *.cc|*.C|*.cxx|*.cpp|*.c++)
 		compiler="$CXX"
 		flags="-o $tmpo $CXXFLAGS $CPPFLAGS $src_or_exe";;
 	    *)


### PR DESCRIPTION
Add support for using .c++ as extension for c++ files.
Looked in the [gcc manual](https://gcc.gnu.org/onlinedocs/gcc-11.2.0/gcc/Overall-Options.html#Overall-Options) that it supports .c++ as extension for c++ code, looks reasonable so I thought it could be nice to add.