### PR TITLE
ignore incompatible-pointer-types errors

### DIFF
--- a/scripts/mkc_check_funclib.in
+++ b/scripts/mkc_check_funclib.in
@@ -79,6 +79,10 @@ check_itself (){
     fname="$funcname"
 
     cat > "$tmpc" <<EOF
+#if defined __GNUC__ && __GNUC__ >= 14
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+#endif
+
 void yylex ();
 void yylex () {}
 


### PR DESCRIPTION
GCC 14 errors with incompatible-pointer-types however, it is unavoidable in the way mkc_check_funclib checks for functions.

Fixes: #29